### PR TITLE
Bug fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
 version: 2
 updates:
 - package-ecosystem: nuget
-  directory: "/AzurePipelinesToGitHubActionsConverter/AzurePipelinesToGitHubActionsConverter.Core"
+  directory: "/src/AzurePipelinesToGitHubActionsConverter.Core"
   schedule:
     interval: daily
     time: "06:00"
     timezone: America/New_York
   open-pull-requests-limit: 10
+  assignees:
+  - "samsmithnz"

--- a/src/AnimalsSerialization.Tests/Conversion/FarmConversionAlex.cs
+++ b/src/AnimalsSerialization.Tests/Conversion/FarmConversionAlex.cs
@@ -3,6 +3,7 @@ using System;
 
 namespace AnimalSerialization.Tests.Conversion
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class FarmConversionAlex
     {
 

--- a/src/AnimalsSerialization.Tests/Conversion/FarmConversionSam.cs
+++ b/src/AnimalsSerialization.Tests/Conversion/FarmConversionSam.cs
@@ -3,6 +3,7 @@ using System;
 
 namespace AnimalSerialization.Tests.Conversion
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class FarmConversionSam
     {
 

--- a/src/AnimalsSerialization.Tests/Conversion/FarmResponse.cs
+++ b/src/AnimalsSerialization.Tests/Conversion/FarmResponse.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace AnimalSerialization.Tests.Conversion
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class FarmResponse
     {
         public FarmResponse()

--- a/src/AnimalsSerialization.Tests/Conversion/FarmSerialization.cs
+++ b/src/AnimalsSerialization.Tests/Conversion/FarmSerialization.cs
@@ -2,6 +2,7 @@
 
 namespace AnimalSerialization.Tests.Conversion
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public static class FarmSerialization
     {
         public static T Deserialize<T>(string yaml)

--- a/src/AnimalsSerialization.Tests/Models/Barn.cs
+++ b/src/AnimalsSerialization.Tests/Models/Barn.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace AnimalSerialization.Tests.Models
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class Barn
     {
         public string BarnType { get; set; }

--- a/src/AnimalsSerialization.Tests/Models/Dog.cs
+++ b/src/AnimalsSerialization.Tests/Models/Dog.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace AnimalSerialization.Tests.Models
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class Dog
     {
         public string Name { get; set; }

--- a/src/AnimalsSerialization.Tests/Models/Farm.cs
+++ b/src/AnimalsSerialization.Tests/Models/Farm.cs
@@ -1,5 +1,6 @@
 ﻿namespace AnimalSerialization.Tests.Models
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class Farm<TFarmItem1, TFarmItem2>
     {
         public TFarmItem1 FarmItem1 { get; set; }

--- a/src/AnimalsSerialization.Tests/Models/Sheep.cs
+++ b/src/AnimalsSerialization.Tests/Models/Sheep.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace AnimalSerialization.Tests.Models
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class Sheep
     {
         public string Type { get; set; }

--- a/src/AnimalsSerialization.Tests/Models/Silo.cs
+++ b/src/AnimalsSerialization.Tests/Models/Silo.cs
@@ -4,6 +4,7 @@ using System.Text;
 
 namespace AnimalSerialization.Tests.Models
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class Silo
     {
         public int HeightInFeet { get; set; }

--- a/src/AnimalsSerialization.Tests/Models/Tractor.cs
+++ b/src/AnimalsSerialization.Tests/Models/Tractor.cs
@@ -1,5 +1,6 @@
 ﻿namespace AnimalSerialization.Tests.Models
 {
+    [System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
     public class Tractor
     {
         public string ModelType { get; set; }

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Parameter.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelines/Parameter.cs
@@ -1,12 +1,12 @@
-﻿using System.Collections.Generic;
-namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
-{
-    public class Parameter
-    {
-        public string name { get; set; }
-        public string displayName { get; set; }
-        public string type { get; set; }
-        public string @default { get; set; }
-        public string[] values { get; set; }
-    }
-}
+﻿//using System.Collections.Generic;
+//namespace AzurePipelinesToGitHubActionsConverter.Core.AzurePipelines
+//{
+//    public class Parameter
+//    {
+//        public string name { get; set; }
+//        public string displayName { get; set; }
+//        public string type { get; set; }
+//        public string @default { get; set; }
+//        public string[] values { get; set; }
+//    }
+//}

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelinesToGitHubActionsConverter.Core.csproj
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelinesToGitHubActionsConverter.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.10.3.0</Version>
+    <Version>0.10.4.0</Version>
     <Deterministic>false</Deterministic>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/samsmithnz/AzurePipelinesToGitHubActionsConverter</PackageProjectUrl>

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelinesToGitHubActionsConverter.Core.csproj
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelinesToGitHubActionsConverter.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.10.5.0</Version>
+    <Version>0.10.6.0</Version>
     <Deterministic>false</Deterministic>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/samsmithnz/AzurePipelinesToGitHubActionsConverter</PackageProjectUrl>

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelinesToGitHubActionsConverter.Core.csproj
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/AzurePipelinesToGitHubActionsConverter.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>0.10.4.0</Version>
+    <Version>0.10.5.0</Version>
     <Deterministic>false</Deterministic>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/samsmithnz/AzurePipelinesToGitHubActionsConverter</PackageProjectUrl>

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion.cs
@@ -26,6 +26,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             GitHubActionsRoot gitHubActions = null;
 
             //Run some processing to convert simple pools and demands to the complex editions, to avoid adding to the combinations below.
+            //Also clean and remove variables with reserved words that get into trouble during deserialization. HACK alert... :(
             input = CleanYamlBeforeDeserialization(input);
 
             //Start the main deserialization methods

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion.cs
@@ -244,7 +244,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
                         line.ToLower().IndexOf("parameters:", StringComparison.OrdinalIgnoreCase) >= 0)
                     {
                         string[] items = line.Split(':');
-                        if (items.Length > 1 && items[0].ToString().Trim().Length > 0)
+                        if (items.Length == 2 && items[0].ToString().Trim().Length > 0)
                         {
                             variablePrefixSpaceCount = items[0].TakeWhile(char.IsWhiteSpace).Count();
                             //now that we have the variables start, we need to loop through the variable prefix space count + 2

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/StepsProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/StepsProcessing.cs
@@ -238,6 +238,10 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
             {
                 runScript += GetStepInput(step, "projects") + " ";
             }
+            if (step.inputs.ContainsKey("packagesToPack") == true)
+            {
+                runScript += GetStepInput(step, "packagesToPack") + " ";
+            }
             if (step.inputs.ContainsKey("arguments") == true)
             {
                 runScript += GetStepInput(step, "arguments") + " ";

--- a/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/StepsProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/Conversion/StepsProcessing.cs
@@ -230,33 +230,42 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.Conversion
 
         private GitHubActions.Step CreateDotNetCommandStep(AzurePipelines.Step step)
         {
-            if (step.inputs is null)
-                return null;//this is a misconfigured task
-            string runScript = "dotnet ";
-            if (step.inputs.ContainsKey("command") == true)
+            if (step.inputs != null)
             {
-                runScript += GetStepInput(step, "command") + " ";
-            }
-            if (step.inputs.ContainsKey("projects") == true)
-            {
-                runScript += GetStepInput(step, "projects") + " ";
-            }
-            if (step.inputs.ContainsKey("packagesToPack") == true)
-            {
-                runScript += GetStepInput(step, "packagesToPack") + " ";
-            }
-            if (step.inputs.ContainsKey("arguments") == true)
-            {
-                runScript += GetStepInput(step, "arguments") + " ";
-            }
-            //Remove the new line characters
-            runScript = runScript.Replace("\n", "");
-            GitHubActions.Step gitHubStep = new GitHubActions.Step
-            {
-                run = runScript
-            };
+                string runScript = "dotnet ";
+                if (step.inputs.ContainsKey("command") == true)
+                {
+                    runScript += GetStepInput(step, "command") + " ";
+                }
+                if (step.inputs.ContainsKey("projects") == true)
+                {
+                    runScript += GetStepInput(step, "projects") + " ";
+                }
+                if (step.inputs.ContainsKey("packagestopack") == true)
+                {
+                    runScript += GetStepInput(step, "packagesToPack") + " ";
+                }
+                if (step.inputs.ContainsKey("arguments") == true)
+                {
+                    runScript += GetStepInput(step, "arguments") + " ";
+                }
+                //Remove the new line characters
+                runScript = runScript.Replace("\n", "");
+                GitHubActions.Step gitHubStep = new GitHubActions.Step
+                {
+                    run = runScript
+                };
 
-            return gitHubStep;
+                return gitHubStep;
+            }
+            else
+            {
+                GitHubActions.Step gitHubStep = new GitHubActions.Step
+                {
+                    step_message = "This DotNetCoreCLI task is misconfigured, inputs are required"
+                };
+                return gitHubStep;
+            }
         }
 
         private GitHubActions.Step CreateDownloadBuildArtifacts(AzurePipelines.Step step)

--- a/src/AzurePipelinesToGitHubActionsConverter.Tests/CompletePipelineTests.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Tests/CompletePipelineTests.cs
@@ -535,7 +535,7 @@ jobs:
     - name: Publish
       run: dotnet publish MyProject/MyProject.Models/MyProject.Models.csproj --configuration ${{ env.BuildConfiguration }} --output ${GITHUB_WORKSPACE}
     - name: dotnet pack
-      run: dotnet pack
+      run: dotnet pack MyProject/MyProject.Models/MyProject.Models.csproj
     - name: Publish Artifact
       uses: actions/upload-artifact@v2
       with:

--- a/src/AzurePipelinesToGitHubActionsConverter.Tests/StagesTests.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Tests/StagesTests.cs
@@ -254,5 +254,30 @@ jobs:
             Assert.AreEqual(expected, gitHubOutput.actionsYaml);
         }
 
+        //Test that stages translate to jobs correctly.
+        [TestMethod]
+        public void StagingNoJobsPipelineTest()
+        {
+            //Arrange
+            Conversion conversion = new Conversion();
+            string yaml = @"
+stages:
+- stage: BuildA
+  displayName: 'BuildA Stage'
+";
+
+            //Act
+            ConversionResponse gitHubOutput = conversion.ConvertAzurePipelineToGitHubAction(yaml);
+
+            //Assert
+            string expected = @"
+#Note that although having no jobs is valid YAML, it is not a valid GitHub Action.
+jobs: {}
+";
+
+            expected = UtilityTests.TrimNewLines(expected);
+            Assert.AreEqual(expected, gitHubOutput.actionsYaml);
+        }
+
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.Tests/StepsTests.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Tests/StepsTests.cs
@@ -481,6 +481,135 @@ namespace AzurePipelinesToGitHubActionsConverter.Tests
         }
 
         [TestMethod]
+        public void DotNetCoreCLIRestoreIndividualStepTest()
+        {
+            //Arrange
+            Conversion conversion = new Conversion();
+            string yaml = @"
+- task: DotNetCoreCLI@2
+  displayName: Restore
+  inputs:
+    command: restore
+    projects: MyProject/MyProject.Models/MyProject.Models.csproj
+";
+
+            //Act
+            ConversionResponse gitHubOutput = conversion.ConvertAzurePipelineTaskToGitHubActionTask(yaml);
+
+            //Assert
+            string expected = @"
+
+";
+            expected = UtilityTests.TrimNewLines(expected);
+            Assert.AreEqual(expected, gitHubOutput.actionsYaml);
+        }
+
+        [TestMethod]
+        public void DotNetCoreCLIBuildIndividualStepTest()
+        {
+            //Arrange
+            Conversion conversion = new Conversion();
+            string yaml = @"
+- task: DotNetCoreCLI@2
+  displayName: Build
+  inputs:
+    projects: MyProject/MyProject.Models/MyProject.Models.csproj
+    arguments: '--configuration $(BuildConfiguration)'
+";
+
+            //Act
+            ConversionResponse gitHubOutput = conversion.ConvertAzurePipelineTaskToGitHubActionTask(yaml);
+
+            //Assert
+            string expected = @"
+- name: Build
+  run: dotnet MyProject/MyProject.Models/MyProject.Models.csproj --configuration ${{ env.BuildConfiguration }}
+";
+            expected = UtilityTests.TrimNewLines(expected);
+            Assert.AreEqual(expected, gitHubOutput.actionsYaml);
+        }
+
+
+
+        [TestMethod]
+        public void DotNetCoreCLIPublishIndividualStepTest()
+        {
+            //Arrange
+            Conversion conversion = new Conversion();
+            string yaml = @"
+- task: DotNetCoreCLI@2
+  displayName: Publish
+  inputs:
+    command: publish
+    publishWebProjects: false
+    projects: MyProject/MyProject.Models/MyProject.Models.csproj
+    arguments: '--configuration $(BuildConfiguration) --output $(build.artifactstagingdirectory)'
+    zipAfterPublish: false
+";
+
+            //Act
+            ConversionResponse gitHubOutput = conversion.ConvertAzurePipelineTaskToGitHubActionTask(yaml);
+
+            //Assert
+            string expected = @"
+- name: Publish
+  run: dotnet publish MyProject/MyProject.Models/MyProject.Models.csproj --configuration ${{ env.BuildConfiguration }} --output ${GITHUB_WORKSPACE}
+";
+            expected = UtilityTests.TrimNewLines(expected);
+            Assert.AreEqual(expected, gitHubOutput.actionsYaml);
+        }
+
+
+
+        [TestMethod]
+        public void DotNetCoreCLIPackIndividualStepTest()
+        {
+            //Arrange
+            Conversion conversion = new Conversion();
+            string yaml = @"
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet pack'
+  inputs:
+    command: pack
+    packagesToPack: MyProject/MyProject.Models/MyProject.Models.csproj
+    versioningScheme: byEnvVar
+    versionEnvVar: BuildVersion
+";
+
+            //Act
+            ConversionResponse gitHubOutput = conversion.ConvertAzurePipelineTaskToGitHubActionTask(yaml);
+
+            //Assert
+            string expected = @"
+- name: dotnet pack
+  run: dotnet pack MyProject/MyProject.Models/MyProject.Models.csproj
+";
+            expected = UtilityTests.TrimNewLines(expected);
+            Assert.AreEqual(expected, gitHubOutput.actionsYaml);
+        }
+
+        [TestMethod]
+        public void DotNetCoreCLIInvalidIndividualStepTest()
+        {
+            //Arrange
+            Conversion conversion = new Conversion();
+            string yaml = @"
+- task: DotNetCoreCLI@2
+  displayName: 'dotnet build but no inputs'
+";
+
+            //Act
+            ConversionResponse gitHubOutput = conversion.ConvertAzurePipelineTaskToGitHubActionTask(yaml);
+
+            //Assert
+            string expected = @"
+
+";
+            expected = UtilityTests.TrimNewLines(expected);
+            Assert.AreEqual(expected, gitHubOutput.actionsYaml);
+        }
+
+        [TestMethod]
         public void SwapSlotsIndividualStepTest()
         {
             //Arrange

--- a/src/AzurePipelinesToGitHubActionsConverter.Tests/StepsTests.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Tests/StepsTests.cs
@@ -498,7 +498,8 @@ namespace AzurePipelinesToGitHubActionsConverter.Tests
 
             //Assert
             string expected = @"
-
+- name: Restore
+  run: dotnet restore MyProject/MyProject.Models/MyProject.Models.csproj
 ";
             expected = UtilityTests.TrimNewLines(expected);
             Assert.AreEqual(expected, gitHubOutput.actionsYaml);
@@ -603,7 +604,8 @@ namespace AzurePipelinesToGitHubActionsConverter.Tests
 
             //Assert
             string expected = @"
-
+- #: This DotNetCoreCLI task is misconfigured, inputs are required
+  name: dotnet build but no inputs
 ";
             expected = UtilityTests.TrimNewLines(expected);
             Assert.AreEqual(expected, gitHubOutput.actionsYaml);

--- a/src/AzurePipelinesToGitHubActionsConverter.Tests/TemplateTests.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Tests/TemplateTests.cs
@@ -77,7 +77,7 @@ jobs:
       shell: powershell";
             expected = UtilityTests.TrimNewLines(expected);
             Assert.AreEqual(expected, gitHubOutput.actionsYaml);
-        }        
+        }    
 
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.Tests/VariableTests.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Tests/VariableTests.cs
@@ -325,7 +325,13 @@ env:
             //Arrange
             string input = @"
 parameters: # defaults for any parameters that aren't specified
-  environment: 'Dev'";
+  #environment: 'Dev'
+  #strategy: 'have one'
+  #pool: 'heated'
+  #variables: 'yes'
+  #workspace: 'no'
+  plainVar: 'ok'
+";
             Conversion conversion = new Conversion();
 
             //Act
@@ -333,9 +339,9 @@ parameters: # defaults for any parameters that aren't specified
 
             //Assert
             string expected = @"
-variables: # defaults for any parameters that aren't specified
-  environment: 'Dev'  
-  ";
+env:
+  plainVar: ok
+";
             expected = UtilityTests.TrimNewLines(expected);
             Assert.AreEqual(expected, gitHubOutput.actionsYaml);
         }

--- a/src/AzurePipelinesToGitHubActionsConverter.Tests/VariableTests.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Tests/VariableTests.cs
@@ -325,12 +325,8 @@ env:
             //Arrange
             string input = @"
 parameters: # defaults for any parameters that aren't specified
-  #environment: 'Dev'
-  #strategy: 'have one'
-  #pool: 'heated'
-  #variables: 'yes'
-  #workspace: 'no'
   plainVar: 'ok'
+  environment2: 'Dev'
 ";
             Conversion conversion = new Conversion();
 
@@ -341,6 +337,7 @@ parameters: # defaults for any parameters that aren't specified
             string expected = @"
 env:
   plainVar: ok
+  environment2: Dev
 ";
             expected = UtilityTests.TrimNewLines(expected);
             Assert.AreEqual(expected, gitHubOutput.actionsYaml);

--- a/src/AzurePipelinesToGitHubActionsConverter.Tests/VariableTests.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Tests/VariableTests.cs
@@ -327,7 +327,10 @@ env:
 parameters: # defaults for any parameters that aren't specified
   plainVar: 'ok'
   environment: 'Dev'
+  strategy: Dev
+  pool: 'Dev'
 ";
+
             Conversion conversion = new Conversion();
 
             //Act
@@ -337,7 +340,9 @@ parameters: # defaults for any parameters that aren't specified
             string expected = @"
 env:
   plainVar: ok
-  environment: Dev
+  environment2: Dev
+  strategy2: Dev
+  pool2: Dev
 ";
             expected = UtilityTests.TrimNewLines(expected);
             Assert.AreEqual(expected, gitHubOutput.actionsYaml);

--- a/src/AzurePipelinesToGitHubActionsConverter.Tests/VariableTests.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Tests/VariableTests.cs
@@ -326,7 +326,7 @@ env:
             string input = @"
 parameters: # defaults for any parameters that aren't specified
   plainVar: 'ok'
-  environment2: 'Dev'
+  environment: 'Dev'
 ";
             Conversion conversion = new Conversion();
 
@@ -337,7 +337,7 @@ parameters: # defaults for any parameters that aren't specified
             string expected = @"
 env:
   plainVar: ok
-  environment2: Dev
+  environment: Dev
 ";
             expected = UtilityTests.TrimNewLines(expected);
             Assert.AreEqual(expected, gitHubOutput.actionsYaml);

--- a/src/AzurePipelinesToGitHubActionsConverter.Tests/VariableTests.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Tests/VariableTests.cs
@@ -262,5 +262,27 @@ env:
             Assert.AreEqual(expected, gitHubOutput.actionsYaml);
         }
 
+
+        [TestMethod]
+        public void ParametersReservedWordTest()
+        {
+            //Arrange
+            string input = @"
+parameters: # defaults for any parameters that aren't specified
+  environment: 'Dev'";
+            Conversion conversion = new Conversion();
+
+            //Act
+            ConversionResponse gitHubOutput = conversion.ConvertAzurePipelineToGitHubAction(input);
+
+            //Assert
+            string expected = @"
+variables: # defaults for any parameters that aren't specified
+  environment: 'Dev'  
+  ";
+            expected = UtilityTests.TrimNewLines(expected);
+            Assert.AreEqual(expected, gitHubOutput.actionsYaml);
+        }
+
     }
 }

--- a/src/AzurePipelinesToGitHubActionsConverter.sln
+++ b/src/AzurePipelinesToGitHubActionsConverter.sln
@@ -10,10 +10,11 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{90C45174-BE52-4642-BBB4-609E29A8CE48}"
 	ProjectSection(SolutionItems) = preProject
 		BuildVersion.ps1 = BuildVersion.ps1
+		..\.github\dependabot.yml = ..\.github\dependabot.yml
 		..\README.md = ..\README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AnimalsSerialization.Tests", "AnimalsSerialization.Tests\AnimalsSerialization.Tests.csproj", "{D037B7D2-1B96-4172-8835-B26EF836F5CC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AnimalsSerialization.Tests", "AnimalsSerialization.Tests\AnimalsSerialization.Tests.csproj", "{D037B7D2-1B96-4172-8835-B26EF836F5CC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
When a variable contains a word that appears in another part of the hierarchy, it tries to convert it, and crashes, for example: "environment". 