### PR TITLE
Initialize environment variable in ProcessEnvironmentV2 method

### DIFF
--- a/src/AzurePipelinesToGitHubActionsConverter.Core/PipelinesToActionsConversion/GeneralProcessing.cs
+++ b/src/AzurePipelinesToGitHubActionsConverter.Core/PipelinesToActionsConversion/GeneralProcessing.cs
@@ -47,7 +47,7 @@ namespace AzurePipelinesToGitHubActionsConverter.Core.PipelinesToActionsConversi
 
         public AzurePipelines.Environment ProcessEnvironmentV2(string environmentYaml)
         {
-            AzurePipelines.Environment environment = null;
+            AzurePipelines.Environment environment = new AzurePipelines.Environment();
             if (environmentYaml != null)
             {
                 try


### PR DESCRIPTION
This pull request includes a minor update to the `ProcessEnvironmentV2` method in `GeneralProcessing.cs`. The change initializes the `environment` variable with a new instance of `AzurePipelines.Environment` instead of setting it to `null`.